### PR TITLE
docs: fix README badges (retired Marketplace badges + stale maintenance year)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # json2csv
 
-[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/khaeransori.json2csv?cacheSeconds=3600)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv)
-[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/khaeransori.json2csv?cacheSeconds=3600)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv)
-[![Visual Studio Marketplace Rating](https://img.shields.io/visual-studio-marketplace/stars/khaeransori.json2csv?cacheSeconds=3600)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv&ssr=false#review-details)
+[![Visual Studio Marketplace Version](https://vsmarketplacebadges.dev/version-short/khaeransori.json2csv.svg)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv)
+[![Visual Studio Marketplace Downloads](https://vsmarketplacebadges.dev/downloads-short/khaeransori.json2csv.svg)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv)
+[![Visual Studio Marketplace Rating](https://vsmarketplacebadges.dev/rating-short/khaeransori.json2csv.svg)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv&ssr=false#review-details)
 ![GitHub License](https://img.shields.io/github/license/khaeransori/vscode-json2csv)
 ![GitHub Issues](https://img.shields.io/github/issues/khaeransori/vscode-json2csv)
 ![GitHub Last Commit](https://img.shields.io/github/last-commit/khaeransori/vscode-json2csv)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
 # json2csv
 
-![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/khaeransori.json2csv)
-![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/khaeransori.json2csv)
-![Visual Studio Marketplace Rating](https://img.shields.io/visual-studio-marketplace/stars/khaeransori.json2csv)
+[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/khaeransori.json2csv?cacheSeconds=3600)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv)
+[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/khaeransori.json2csv?cacheSeconds=3600)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv)
+[![Visual Studio Marketplace Rating](https://img.shields.io/visual-studio-marketplace/stars/khaeransori.json2csv?cacheSeconds=3600)](https://marketplace.visualstudio.com/items?itemName=khaeransori.json2csv&ssr=false#review-details)
 ![GitHub License](https://img.shields.io/github/license/khaeransori/vscode-json2csv)
 ![GitHub Issues](https://img.shields.io/github/issues/khaeransori/vscode-json2csv)
 ![GitHub Last Commit](https://img.shields.io/github/last-commit/khaeransori/vscode-json2csv)
-![Maintenance](https://img.shields.io/maintenance/yes/2024)
+![Maintenance](https://img.shields.io/maintenance/yes/2026)
 
 **json2csv** is a Visual Studio Code extension that allows you to easily convert between JSON and CSV formats, directly within the editor. It is designed to simplify data manipulation and format conversion for developers and data analysts, with support for **lossless conversion of big integer numbers**.
 


### PR DESCRIPTION
## Summary
The README's Visual Studio Marketplace badges were rendering as a grey **"retired badge"** placeholder, and the Maintenance badge was pinned to **2024**.

## Root cause
shields.io **retired** its `visual-studio-marketplace` badges. The version, downloads, and rating endpoints now all return a `retired badge` message instead of real data — confirmed directly:
```
img.shields.io/visual-studio-marketplace/v|d|stars/khaeransori.json2csv → {"message":"retired badge", ...}
```

## Fix
- Switch the three Marketplace badges to **`vsmarketplacebadges.dev`**, which serves live data — verified:
  - version → **v1.0.0**
  - downloads → **349.59K**
  - rating → **4.12/5 (17)**
- Keep the badges **clickable** to the Marketplace listing.
- Bump the **Maintenance** badge year **2024 → 2026**.

GitHub badges (license / issues / last-commit) were unaffected — those shields endpoints still work — and are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgooSxnm8nPsZf7HmrMbV6)_