### PR TITLE
chore: CI fail-fast off + release 1.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1] - 2026-06-24
 
 ### Fixed
 - CSV to JSON conversion now auto-detects the input's line endings, so CRLF (Windows) and CR (classic Mac) files no longer leave a stray carriage return on the last field of each row, and input ending in a trailing newline no longer produces an empty trailing record ([#22](https://github.com/khaeransori/vscode-json2csv/issues/22)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json2csv",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json2csv",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "json-2-csv": "^5.5.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "json2csv",
   "displayName": "JSON to CSV",
   "description": "Bidirectional JSON-CSV Converter - transform JSON files into CSV and CSV files into JSON with ease.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Khaer Ansori",
     "email": "hello@khaeransori.com",


### PR DESCRIPTION
## Summary
Two housekeeping follow-ups:

### CI
- Set `strategy.fail-fast: false` on the build matrix so a failure on one OS no longer cancels the others. (During the #26 work, a macOS failure cancelled the windows job, hiding whether it would have passed.)

### Release 1.0.1
- Bump `version` to `1.0.1` in `package.json` (and synced `package-lock.json`).
- Promote the CHANGELOG `[Unreleased]` section to `## [1.0.1] - 2026-06-24`, covering the CSV→JSON line-ending fix (#22) and the removed `json2csv.toJSON.delimiter.eol` setting.

## Note on publishing
This prepares the release but does **not** publish to the VS Code Marketplace — that requires `vsce publish` with a publisher Personal Access Token, which isn't available in this environment. After merge, publish from your machine (`npx @vscode/vsce publish`) or via a tagged CI workflow, and create the `v1.0.1` git tag/GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgooSxnm8nPsZf7HmrMbV6)_